### PR TITLE
Fix bad formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@
 <hr/>
 
 <div align="center">
-  Learn more about Transword <a href="https://transword.xyz"> from our website here. </a>
+  Learn more about Transword from our website<a href="https://transword.xyz"> here. </a>
 </div>


### PR DESCRIPTION
Changed `from our website here.` to `here`.

Before:
<div align="center">
  Learn more about Transword <a href="https://transword.xyz"> from our website here. </a>
</div>

Now:
<div align="center">
  Learn more about Transword from our website<a href="https://transword.xyz"> here. </a>
</div>